### PR TITLE
광고 배너 구현

### DIFF
--- a/Yes24Ticket/Yes24Ticket/Model/AdCellConfiguration.swift
+++ b/Yes24Ticket/Yes24Ticket/Model/AdCellConfiguration.swift
@@ -1,0 +1,24 @@
+//
+//  AdCellConfiguration.swift
+//  Yes24Ticket
+//
+//  Created by 조성민 on 11/21/24.
+//
+
+import UIKit
+
+struct AdCellConfiguration {
+    
+    let image: UIImage
+    
+}
+
+extension AdCellConfiguration {
+    
+    static let mockData: [AdCellConfiguration] = [
+        .init(image: .icSitBlue18),
+        .init(image: .icnArrayRed18I),
+        .init(image: .icnFillUpI)
+    ]
+    
+}

--- a/Yes24Ticket/Yes24Ticket/Model/TicketRankCellConfiguration.swift
+++ b/Yes24Ticket/Yes24Ticket/Model/TicketRankCellConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  TicketRankConfiguration.swift
+//  TicketRankCellConfiguration.swift
 //  Yes24Ticket
 //
 //  Created by 조성민 on 11/21/24.
@@ -7,16 +7,16 @@
 
 import UIKit
 
-struct TicketRankConfiguration {
+struct TicketRankCellConfiguration {
     
     let image: UIImage
     let rank: Int
     
 }
 
-extension TicketRankConfiguration {
+extension TicketRankCellConfiguration {
     
-    static let mockData: [TicketRankConfiguration] = [
+    static let mockData: [TicketRankCellConfiguration] = [
         .init(image: .icSitBlue18, rank: 1),
         .init(image: .icnX18, rank: 2),
         .init(image: .icIShare36, rank: 3),

--- a/Yes24Ticket/Yes24Ticket/Presentation/Home/AdCollectionViewCell.swift
+++ b/Yes24Ticket/Yes24Ticket/Presentation/Home/AdCollectionViewCell.swift
@@ -1,0 +1,43 @@
+//
+//  AdCollectionViewCell.swift
+//  Yes24Ticket
+//
+//  Created by 조성민 on 11/21/24.
+//
+
+import UIKit
+
+final class AdCollectionViewCell: UICollectionViewCell {
+    
+    private let imageView = UIImageView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+    }
+    
+    private func setUI() {
+        contentView.addSubview(imageView)
+    }
+    
+    private func setLayout() {
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    func configure(_ configuration: AdCellConfiguration) {
+        imageView.image = configuration.image
+    }
+    
+}

--- a/Yes24Ticket/Yes24Ticket/Presentation/Home/HomeViewController.swift
+++ b/Yes24Ticket/Yes24Ticket/Presentation/Home/HomeViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class HomeViewController: UIViewController {
     
     private var mainFooter: IndexBadgeFooterView?
+    private var adFooter: IndexBadgeFooterView?
     
     private let scrollView = UIScrollView()
     
@@ -50,6 +51,10 @@ final class HomeViewController: UIViewController {
             TicketRankFooterView.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,
             withReuseIdentifier: TicketRankFooterView.reusableViewIdentifier
+        )
+        $0.register(
+            AdCollectionViewCell.self,
+            forCellWithReuseIdentifier: AdCollectionViewCell.cellIdentifier
         )
         $0.dataSource = self
         $0.delegate = self
@@ -107,6 +112,8 @@ final class HomeViewController: UIViewController {
                 return createCategorySectionLayout()
             case 2:
                 return createTicketRankSectionLayout()
+            case 3:
+                return createAdSectionLayout()
             default:
                 return nil
             }
@@ -239,6 +246,53 @@ final class HomeViewController: UIViewController {
         return section
     }
     
+    private func createAdSectionLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(160)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = .init(
+            top: 8,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
+        )
+        section.orthogonalScrollingBehavior = .groupPaging
+        section.visibleItemsInvalidationHandler = { [weak self] (visibleItems, offset, env) in
+            let currentPage = Int(max(
+                0,
+                round(offset.x / env.container.contentSize.width)
+            ))
+            self?.adFooter?.changeIndex(currentIndex: currentPage + 1)
+        }
+        section.boundarySupplementaryItems = [
+            NSCollectionLayoutBoundarySupplementaryItem(
+                layoutSize: .init(
+                    widthDimension: .absolute(40),
+                    heightDimension: .absolute(20)
+                ),
+                elementKind: UICollectionView.elementKindSectionFooter,
+                alignment: .bottomTrailing,
+                absoluteOffset: CGPoint(
+                    x: -20,
+                    y: -40
+                )
+            )
+        ]
+        
+        return section
+    }
+    
 }
 
 extension HomeViewController: UICollectionViewDelegate {
@@ -262,7 +316,7 @@ extension HomeViewController: UICollectionViewDelegate {
 extension HomeViewController: UICollectionViewDataSource {
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 3
+        return 4
     }
     
     func collectionView(
@@ -275,7 +329,9 @@ extension HomeViewController: UICollectionViewDataSource {
         case 1:
             CategoryCellConfiguration.mockData.count
         case 2:
-            TicketRankConfiguration.mockData.count
+            TicketRankCellConfiguration.mockData.count
+        case 3:
+            AdCellConfiguration.mockData.count
         default:
             0
         }
@@ -296,6 +352,7 @@ extension HomeViewController: UICollectionViewDataSource {
                 return UICollectionReusableView()
             }
             // TODO: API 데이터로 수정
+            footer.setDimMode(isWhite: true)
             footer.setMaxIndex(MainCellConfiguration.mockData.count)
             footer.changeIndex(currentIndex: 1)
             mainFooter = footer
@@ -326,6 +383,21 @@ extension HomeViewController: UICollectionViewDataSource {
             default:
                 return UICollectionReusableView()
             }
+        case 3:
+            guard let footer = collectionView.dequeueReusableSupplementaryView(
+                ofKind: UICollectionView.elementKindSectionFooter,
+                withReuseIdentifier: IndexBadgeFooterView.reusableViewIdentifier,
+                for: indexPath
+            ) as? IndexBadgeFooterView else {
+                return UICollectionReusableView()
+            }
+            // TODO: API 데이터로 수정
+            footer.setMaxIndex(AdCellConfiguration.mockData.count)
+            footer.changeIndex(currentIndex: 1)
+            footer.setDimMode(isWhite: false)
+            adFooter = footer
+            
+            return footer
         default:
             return UICollectionReusableView()
         }
@@ -363,7 +435,17 @@ extension HomeViewController: UICollectionViewDataSource {
             ) as? TicketRankCollectionViewCell else {
                 return UICollectionViewCell()
             }
-            cell.configure(TicketRankConfiguration.mockData[indexPath.row])
+            cell.configure(TicketRankCellConfiguration.mockData[indexPath.row])
+            
+            return cell
+        case 3:
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: AdCollectionViewCell.cellIdentifier,
+                for: indexPath
+            ) as? AdCollectionViewCell else {
+                return UICollectionViewCell()
+            }
+            cell.configure(AdCellConfiguration.mockData[indexPath.row])
             
             return cell
         default:

--- a/Yes24Ticket/Yes24Ticket/Presentation/Home/HomeViewController.swift
+++ b/Yes24Ticket/Yes24Ticket/Presentation/Home/HomeViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class HomeViewController: UIViewController {
     
-    private var mainFooter: MainFooterView?
+    private var mainFooter: IndexBadgeFooterView?
     
     private let scrollView = UIScrollView()
     
@@ -29,9 +29,9 @@ final class HomeViewController: UIViewController {
             forCellWithReuseIdentifier: MainCollectionViewCell.cellIdentifier
         )
         $0.register(
-            MainFooterView.self,
+            IndexBadgeFooterView.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,
-            withReuseIdentifier: MainFooterView.reusableViewIdentifier
+            withReuseIdentifier: IndexBadgeFooterView.reusableViewIdentifier
         )
         $0.register(
             CategoryCollectionViewCell.self,
@@ -290,9 +290,9 @@ extension HomeViewController: UICollectionViewDataSource {
         case 0:
             guard let footer = collectionView.dequeueReusableSupplementaryView(
                 ofKind: UICollectionView.elementKindSectionFooter,
-                withReuseIdentifier: MainFooterView.reusableViewIdentifier,
+                withReuseIdentifier: IndexBadgeFooterView.reusableViewIdentifier,
                 for: indexPath
-            ) as? MainFooterView else {
+            ) as? IndexBadgeFooterView else {
                 return UICollectionReusableView()
             }
             // TODO: API 데이터로 수정

--- a/Yes24Ticket/Yes24Ticket/Presentation/Home/IndexBadgeFooterView.swift
+++ b/Yes24Ticket/Yes24Ticket/Presentation/Home/IndexBadgeFooterView.swift
@@ -28,12 +28,7 @@ final class IndexBadgeFooterView: UICollectionReusableView {
     }
     
     private func setStyle() {
-        backgroundColor = .whiteDim
         layer.cornerRadius = 10
-        layer.shadowColor = UIColor.black0.cgColor
-        layer.shadowOffset = .init(width: 0, height: 4)
-        layer.shadowOpacity = 0.25
-        layer.shadowRadius = 4
     }
     
     private func setUI() {
@@ -56,6 +51,18 @@ final class IndexBadgeFooterView: UICollectionReusableView {
     
     func setMaxIndex(_ maxIndex: Int) {
         self.maxIndex = maxIndex
+    }
+    
+    func setDimMode(isWhite: Bool) {
+        if isWhite {
+            backgroundColor = .whiteDim
+            layer.shadowColor = UIColor.black0.cgColor
+            layer.shadowOffset = .init(width: 0, height: 4)
+            layer.shadowOpacity = 0.25
+            layer.shadowRadius = 4
+        } else {
+            backgroundColor = .blackDim
+        }
     }
     
 }

--- a/Yes24Ticket/Yes24Ticket/Presentation/Home/IndexBadgeFooterView.swift
+++ b/Yes24Ticket/Yes24Ticket/Presentation/Home/IndexBadgeFooterView.swift
@@ -1,5 +1,5 @@
 //
-//  MainFooterView.swift
+//  IndexBadgeFooterView.swift
 //  Yes24Ticket
 //
 //  Created by 조성민 on 11/20/24.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class MainFooterView: UICollectionReusableView {
+final class IndexBadgeFooterView: UICollectionReusableView {
     
     private var maxIndex: Int?
     

--- a/Yes24Ticket/Yes24Ticket/Presentation/Home/TicketRankCollectionViewCell.swift
+++ b/Yes24Ticket/Yes24Ticket/Presentation/Home/TicketRankCollectionViewCell.swift
@@ -71,7 +71,7 @@ final class TicketRankCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func configure(_ configuration: TicketRankConfiguration) {
+    func configure(_ configuration: TicketRankCellConfiguration) {
         imageView.image = configuration.image
         rankLabel.text = "\(configuration.rank)"
     }


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
홈 화면의 광고 배너를 구현했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- 광고 배너 구현
- 인덱스 뱃지 구현

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->
- 뱃지 재사용
  메인 섹션에서 사용하던 뱃지를 재사용하기 위해서 함수를 통해서 컨트롤 할 수 있도록 구현했습니다.
  메인 섹션에서는 쉐도우가 있고, 배경 색상이 whiteDim인 반면 광고 섹션에서는 쉐도우가 없고 배경 색상이 blackDim이었습니다.
  ```swift
  func setDimMode(isWhite: Bool) {
      if isWhite {
          backgroundColor = .whiteDim
          layer.shadowColor = UIColor.black0.cgColor
          layer.shadowOffset = .init(width: 0, height: 4)
          layer.shadowOpacity = 0.25
          layer.shadowRadius = 4
      } else {
          backgroundColor = .blackDim
      }
  }
  ```

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
| 광고 섹션 |
| :-: |
| ![Simulator Screen Recording - iPhone 13 iOS 18 0 - 2024-11-21 at 22 21 56](https://github.com/user-attachments/assets/3bd25270-3f4a-48cd-ac79-14f5877dc8fc) |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
거의 반복되는 코드라서 BadgeFooter 위주로 봐주시면 될 것 같아요!

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #27 
